### PR TITLE
Remove duplicate fake RAG result rows

### DIFF
--- a/researchcode/Benchmarking-RAG/fake_rag.py
+++ b/researchcode/Benchmarking-RAG/fake_rag.py
@@ -193,20 +193,6 @@ def main():
             'llm_eval': llm_eval
         })
 
-        cosine_similarity_score = calculate_cosine_similarity(model_answer, ref_answer)
-        bert_score = calculate_bertscore(model_answer, ref_answer)
-        llm_eval = evaluate_llm_responses(question, model_answer, ref_answer, openai_api_key)
-
-        results_list.append({
-            'doc_name': doc_name,
-            'question': question,
-            'ref_answer': ref_answer,
-            'model_answer': model_answer,
-            'cosine_similarity': cosine_similarity_score,
-            'bert_score': bert_score,
-            'llm_eval': llm_eval
-        })
-
     results_df = pd.DataFrame(results_list)
     results_df.to_csv('fake_rag_results_test.csv', index=False)
 


### PR DESCRIPTION
## Summary

This PR removes a duplicated result append in `researchcode/Benchmarking-RAG/fake_rag.py`.

Before this change, each evaluated sample was being added to `results_list` twice, which caused duplicate rows in `fake_rag_results_test.csv`. That made the output misleading and could affect any downstream analysis of the benchmark results.

After this change, each sample is recorded exactly once.

## Why

The evaluation loop calculated the same metrics twice and appended the same result payload twice. This was redundant work and produced incorrect output size.

## Testing

- Verified the file still parses with:
  - `env PYTHONPYCACHEPREFIX=/private/tmp/codex-pycache python3 -m py_compile researchcode/Benchmarking-RAG/fake_rag.py`
