### PR TITLE
Add Anote Research Hub: card grid site, search/filter, Pages deploy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Checklist
+
+- [ ] If this PR finishes or updates a research project, I added/updated its card in
+      [`site/data/research.json`](../site/data/research.json) (see [CONTRIBUTING.md](../CONTRIBUTING.md))
+- [ ] Tests/checks pass (if applicable)

--- a/.github/workflows/deploy-research-hub.yml
+++ b/.github/workflows/deploy-research-hub.yml
@@ -1,0 +1,37 @@
+name: Deploy Research Hub
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - ".github/workflows/deploy-research-hub.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "./site"
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to the Anote Research Hub
+
+This repo is now the central hub for Anote's AI research: a card grid linking out to each
+project's GitHub repo, paper, and talk. It is **not** a backlog for planning new research
+features — new research ideas should be designed and built in their own dedicated repo, then
+linked from here once ready.
+
+## Adding or updating a research card
+
+1. Open [`site/data/research.json`](./site/data/research.json).
+2. Add (or edit) an entry with these fields:
+
+   | Field | Required | Description |
+   |-------|----------|--------------|
+   | `id` | yes | Unique slug, e.g. `"retrieval-bench"` |
+   | `title` | yes | Project/paper name |
+   | `description` | yes | 1–3 sentence summary of the research |
+   | `githubUrl` | no | Link to the dedicated repo (or this repo's folder if no dedicated repo exists yet). `null` if none. |
+   | `paperUrl` | no | Link to the paper (PDF, arXiv, or `researchpapers/` file). `null` if none. |
+   | `talkUrl` | no | Link to a recorded talk/video. `null` if none. |
+   | `tags` | yes | Array of category tags used for filtering, e.g. `["RAG", "Benchmarking"]` |
+   | `status` | yes | `"Published"`, `"In Progress"`, or similar |
+
+3. Open a PR. Once merged to `main`, the hub auto-deploys via the
+   [Deploy Research Hub](./.github/workflows/deploy-research-hub.yml) workflow.
+
+## Previewing locally
+
+```bash
+cd site
+python3 -m http.server 8000
+# open http://localhost:8000
+```
+
+No build step or dependencies required — the hub is static HTML/CSS/JS.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Anote AI Research
 
+🔗 **[Browse the Anote Research Hub](https://anote-ai.github.io/Research/)** — a card grid of every Anote AI research project, past and present, with links to code, papers, and talks.
+
 Research papers, benchmark code, presentations, and planning resources from the **Anote AI Research Fellowship**.
 
 The fellowship goal is to produce publishable research across NLP, RAG, agentic AI, and annotation efficiency, with each paper producing a reusable open-source artifact.

--- a/site/app.js
+++ b/site/app.js
@@ -1,0 +1,86 @@
+async function loadResearch() {
+  const res = await fetch("data/research.json");
+  return res.json();
+}
+
+function uniqueTags(items) {
+  const tags = new Set();
+  items.forEach((item) => (item.tags || []).forEach((t) => tags.add(t)));
+  return Array.from(tags).sort();
+}
+
+function cardHTML(item) {
+  const wrapperTag = item.githubUrl ? "a" : "div";
+  const hrefAttr = item.githubUrl ? `href="${item.githubUrl}" target="_blank" rel="noopener"` : "";
+
+  const links = [];
+  if (item.githubUrl) links.push(`<a href="${item.githubUrl}" target="_blank" rel="noopener">GitHub</a>`);
+  if (item.talkUrl) links.push(`<a href="${item.talkUrl}" target="_blank" rel="noopener" onclick="event.stopPropagation()">Talk</a>`);
+  if (item.paperUrl) links.push(`<a href="${item.paperUrl}" target="_blank" rel="noopener" onclick="event.stopPropagation()">Paper</a>`);
+
+  return `
+    <${wrapperTag} class="card" ${hrefAttr} data-id="${item.id}">
+      <span class="status">${item.status || ""}</span>
+      <h2>${item.title}</h2>
+      <p>${item.description || ""}</p>
+      <div class="links">${links.join("") || "<span>No links yet</span>"}</div>
+    </${wrapperTag}>
+  `;
+}
+
+function render(items) {
+  const grid = document.getElementById("grid");
+  const emptyState = document.getElementById("empty-state");
+  grid.innerHTML = items.map(cardHTML).join("");
+  emptyState.hidden = items.length > 0;
+}
+
+function applyFilters(allItems, query, activeTags) {
+  const q = query.trim().toLowerCase();
+  return allItems.filter((item) => {
+    const matchesQuery =
+      !q ||
+      item.title.toLowerCase().includes(q) ||
+      (item.description || "").toLowerCase().includes(q);
+    const matchesTags =
+      activeTags.size === 0 || (item.tags || []).some((t) => activeTags.has(t));
+    return matchesQuery && matchesTags;
+  });
+}
+
+async function init() {
+  const items = await loadResearch();
+  const tags = uniqueTags(items);
+  const activeTags = new Set();
+
+  const tagsContainer = document.getElementById("tags");
+  tagsContainer.innerHTML = tags
+    .map((t) => `<button class="tag-chip" data-tag="${t}">${t}</button>`)
+    .join("");
+
+  const searchInput = document.getElementById("search");
+
+  function refresh() {
+    render(applyFilters(items, searchInput.value, activeTags));
+  }
+
+  searchInput.addEventListener("input", refresh);
+
+  tagsContainer.addEventListener("click", (e) => {
+    const btn = e.target.closest(".tag-chip");
+    if (!btn) return;
+    const tag = btn.dataset.tag;
+    if (activeTags.has(tag)) {
+      activeTags.delete(tag);
+      btn.classList.remove("active");
+    } else {
+      activeTags.add(tag);
+      btn.classList.add("active");
+    }
+    refresh();
+  });
+
+  render(items);
+}
+
+init();

--- a/site/data/research.json
+++ b/site/data/research.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "retrieval-bench",
+    "title": "RetrievalBench: Cross-Domain RAG Retrieval Techniques",
+    "description": "Benchmarks chunking, query expansion, re-ranking, and hybrid search across financial, legal, medical, and technical domains to find which retrieval combination generalizes best. Extends arXiv:2404.07221.",
+    "githubUrl": "https://github.com/anote-ai/Research/tree/main/researchcode/Benchmarking-RAG",
+    "paperUrl": "https://github.com/anote-ai/Research/blob/main/researchpapers/retrieval.pdf",
+    "talkUrl": "https://www.youtube.com/watch?v=a2hQrg2OZ-o",
+    "tags": ["RAG", "Retrieval", "Benchmarking"],
+    "status": "Published"
+  },
+  {
+    "id": "text-classification-bench",
+    "title": "Benchmarking Text Classification",
+    "description": "Compares LLM-based and fine-tuned classifiers across annotation budgets and domains to identify when each approach wins.",
+    "githubUrl": "https://github.com/anote-ai/Research/tree/main/researchcode/Benchmarking-Text-Classification",
+    "paperUrl": "https://github.com/anote-ai/Research/blob/main/researchpapers/classification.pdf",
+    "talkUrl": "https://www.youtube.com/watch?v=IakXvvdaNJQ",
+    "tags": ["Classification", "Benchmarking", "Annotation"],
+    "status": "Published"
+  },
+  {
+    "id": "qa-bench",
+    "title": "Benchmarking Question Answering Models",
+    "description": "Evaluates extractive and generative QA models across enterprise document types to measure accuracy and failure modes.",
+    "githubUrl": "https://github.com/anote-ai/Research/tree/main/researchcode/Benchmarking-Question-Answering",
+    "paperUrl": "https://github.com/anote-ai/Research/blob/main/researchpapers/questionanswering.pdf",
+    "talkUrl": "https://www.youtube.com/watch?v=sppn68PirPQ",
+    "tags": ["Question Answering", "Benchmarking"],
+    "status": "Published"
+  },
+  {
+    "id": "object-detection-bench",
+    "title": "Benchmarking Computer Vision / Object Detection Models",
+    "description": "Compares object detection model families on enterprise imagery tasks, following the structure of nv78/Benchmarking-Computer-Vision-Models.",
+    "githubUrl": "https://github.com/anote-ai/Research/tree/main/researchcode/Benchmarking-ObjectDetection",
+    "paperUrl": null,
+    "talkUrl": null,
+    "tags": ["Computer Vision", "Benchmarking"],
+    "status": "Published"
+  },
+  {
+    "id": "human-ai-teaming",
+    "title": "Human-AI Teaming for Preference Data & Red-Teaming",
+    "description": "Compares human-only, AI-only, and human-AI collaborative preference data construction, and measures the effect on downstream RLHF behavior and bias.",
+    "githubUrl": "https://github.com/anote-ai/Research/issues?q=label%3AT3-HumanAI",
+    "paperUrl": null,
+    "talkUrl": "https://www.youtube.com/watch?v=ZoAsXKLPyuo",
+    "tags": ["Human-AI Teaming", "RLHF", "Active"],
+    "status": "In Progress"
+  },
+  {
+    "id": "agentic-eval",
+    "title": "AgenticEval: Agentic Tool-Calling & Intent Alignment",
+    "description": "Tests whether BFCL rank predicts enterprise deployment trustworthiness, and how small language models compare on intent alignment vs. syntactic accuracy.",
+    "githubUrl": "https://github.com/anote-ai/Research/issues?q=label%3AT1a-AgenticEval",
+    "paperUrl": "https://github.com/anote-ai/Research/blob/main/researchpapers/T1a-AgenticEval/main.tex",
+    "talkUrl": null,
+    "tags": ["Agentic", "Tool-Calling", "Active"],
+    "status": "In Progress"
+  },
+  {
+    "id": "enterprise-synth",
+    "title": "EnterpriseSynth: Synthetic Data for Private Agentic Workflows",
+    "description": "Generates verified agentic SFT and eval data directly from an OpenAPI/Swagger schema, without executing a single real API call.",
+    "githubUrl": "https://github.com/anote-ai/Research/issues?q=label%3AT1b-EnterpriseSynth",
+    "paperUrl": "https://github.com/anote-ai/Research/blob/main/researchpapers/T1b-EnterpriseSynth/main.tex",
+    "talkUrl": null,
+    "tags": ["Synthetic Data", "Agentic", "Active"],
+    "status": "In Progress"
+  },
+  {
+    "id": "annotate-bench",
+    "title": "AnnotateBench: Annotation Requirements Across NLP Tasks",
+    "description": "Benchmarks 5 annotation strategies across 10 datasets and 5 budget levels, fitting learning curves and cost-accuracy Pareto frontiers.",
+    "githubUrl": "https://github.com/anote-ai/Research/issues?q=label%3AT2a-AnnotateBench",
+    "paperUrl": "https://github.com/anote-ai/Research/blob/main/researchpapers/T2a-AnnotateBench/main.tex",
+    "talkUrl": null,
+    "tags": ["Annotation", "Benchmarking", "Active"],
+    "status": "In Progress"
+  },
+  {
+    "id": "annotate-roi",
+    "title": "AnnotateROI: Measuring Annotation Return on Investment",
+    "description": "Builds a cost model, stopping criterion, and LLM-vs-human decision tree so enterprises know when they've labeled enough data.",
+    "githubUrl": "https://github.com/anote-ai/Research/issues?q=label%3AT2b-AnnotateROI",
+    "paperUrl": "https://github.com/anote-ai/Research/blob/main/researchpapers/T2b-AnnotateROI/main.tex",
+    "talkUrl": null,
+    "tags": ["Annotation", "Active"],
+    "status": "In Progress"
+  },
+  {
+    "id": "rag-failure-prop",
+    "title": "RAG Failure Propagation in Agentic Pipelines",
+    "description": "Builds an empirical taxonomy of how retrieval errors propagate, compound, or get corrected across multi-step agentic RAG pipelines.",
+    "githubUrl": "https://github.com/anote-ai/Research/issues?q=label%3AT4-RAGFailure",
+    "paperUrl": "https://github.com/anote-ai/Research/blob/main/researchpapers/T4-RAGFailureProp/main.tex",
+    "talkUrl": null,
+    "tags": ["RAG", "Agentic", "Active"],
+    "status": "In Progress"
+  },
+  {
+    "id": "fine-tuning-llms-talk",
+    "title": "Fine-Tuning LLMs",
+    "description": "Talk on practical strategies and trade-offs for fine-tuning large language models for enterprise use cases.",
+    "githubUrl": null,
+    "paperUrl": null,
+    "talkUrl": "https://www.youtube.com/watch?v=mMmaTMuRZmo",
+    "tags": ["Fine-Tuning", "Talk"],
+    "status": "Published"
+  },
+  {
+    "id": "few-shot-learning-talk",
+    "title": "Few Shot Learning (TED Talk)",
+    "description": "A TED-style talk on few-shot learning techniques and their implications for accessible AI.",
+    "githubUrl": null,
+    "paperUrl": null,
+    "talkUrl": "https://www.youtube.com/watch?v=7I_pBLjMNzs",
+    "tags": ["Few-Shot", "Talk"],
+    "status": "Published"
+  }
+]

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Anote AI Research Hub</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="hub-header">
+    <h1>Anote AI Research</h1>
+    <p>A central hub for Anote's AI research — papers, benchmark code, and talks, past and present.</p>
+    <div class="controls">
+      <input id="search" type="search" placeholder="Search research..." aria-label="Search research" />
+      <div id="tags" class="tags"></div>
+    </div>
+  </header>
+
+  <main id="grid" class="grid"></main>
+  <p id="empty-state" class="empty-state" hidden>No research matches your search/filter.</p>
+
+  <footer>
+    <p>Want to add your project? See <a href="https://github.com/anote-ai/Research/blob/main/CONTRIBUTING.md">CONTRIBUTING.md</a>.</p>
+  </footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/site/style.css
+++ b/site/style.css
@@ -1,0 +1,156 @@
+:root {
+  --bg: #0b0c10;
+  --card-bg: #15171c;
+  --border: #2a2d35;
+  --text: #f2f2f2;
+  --muted: #9a9ea7;
+  --accent: #6c5ce7;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.hub-header {
+  padding: 48px 24px 24px;
+  text-align: center;
+}
+
+.hub-header h1 {
+  margin: 0 0 8px;
+  font-size: 2.25rem;
+}
+
+.hub-header p {
+  margin: 0 0 24px;
+  color: var(--muted);
+}
+
+.controls {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+#search {
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--card-bg);
+  color: var(--text);
+  font-size: 1rem;
+}
+
+.tags {
+  margin-top: 12px;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.tag-chip {
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--card-bg);
+  color: var(--muted);
+  font-size: 0.85rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.tag-chip.active {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+
+.grid {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 20px;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  text-decoration: none;
+  color: var(--text);
+  transition: transform 0.15s ease, border-color 0.15s ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+.card h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  flex-grow: 1;
+}
+
+.card .status {
+  font-size: 0.75rem;
+  color: var(--accent);
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.card .links {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+}
+
+.card .links a {
+  color: var(--text);
+  text-decoration: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 10px;
+}
+
+.card .links a:hover {
+  border-color: var(--accent);
+}
+
+.empty-state {
+  text-align: center;
+  color: var(--muted);
+  padding: 40px;
+}
+
+footer {
+  text-align: center;
+  padding: 24px;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+footer a {
+  color: var(--accent);
+}


### PR DESCRIPTION
## Summary
- Adds a static "Anote Research Hub" site (`site/`) — a card grid where each card shows a research project's title, description, GitHub link, paper link, and talk/video link, modeled on the Community landing page.
- Content lives in `site/data/research.json` (12 entries: published benchmarks, in-progress fellowship tracks, and standalone talks).
- Search box + tag-chip filtering (`site/app.js`).
- `.github/workflows/deploy-research-hub.yml` auto-deploys `site/` to GitHub Pages on push to `main`.
- `CONTRIBUTING.md` + PR template checklist item document how to add/update a card going forward.
- README now links to the live hub at the top.

Closes #51, #52, #53, #54, #55.

## Test plan
- [x] Served `site/` locally with `python3 -m http.server` and confirmed `index.html` loads and `data/research.json` parses (12 entries)
- [ ] After merge, enable GitHub Pages in repo Settings → Pages → Source: "GitHub Actions" (cannot be set via API)
- [ ] Confirm hub renders at https://anote-ai.github.io/Research/ once Pages is enabled and the workflow runs
- [ ] Spot-check a few card links (GitHub/paper/talk) open correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_01RtVZTGxra4hq2hD8EXV56z)_